### PR TITLE
url endpoint to track unauthenticated users before redirecting to final url

### DIFF
--- a/components/class-bstat.php
+++ b/components/class-bstat.php
@@ -240,6 +240,13 @@ class bStat
 		$this->set_identity_cookie( $user_id );
 	}//end set_auth_cookie
 
+	/**
+	 * set the bStat identity cookie for a given user. we use WP's auth cookie
+	 * mechanism to generate the cookie so it can be validated when we read
+	 * it back later.
+	 *
+	 * @param $user_id (WP User ID - note: not User object)
+	 */
 	public function set_identity_cookie( $user_id )
 	{
 		$expiration_time = time() + $this->options()->identity_cookie->duration;


### PR DESCRIPTION
- cookie users that load urls with the pattern /$cookie_url_base/user_id/redirect_url and redirect them to redirect_url
- implemented a local get_current_user_id() function to return either the id of an authenticated user or the id of the cookied user

related to [this other pull request](https://github.com/GigaOM/gigaom/pull/4343)
see https://github.com/GigaOM/legacy-pro/issues/3168

note to @zbtirrell @borkweb, once this pull req is merged, we can update the urls in our alerts to something like `http://accounts.gigaom.com/b/{$user_id}/{$destination_url}` to add tracking for these users in bStat when they click on links in alerts emails. this will set a cookie on their browsers so we can track them even when they're not logged in. [There're more details in ticket 3168.](https://github.com/GigaOM/legacy-pro/issues/3168)
