### PR TITLE
the bstat redirect does not require a wp id any more

### DIFF
--- a/components/class-bstat.php
+++ b/components/class-bstat.php
@@ -33,7 +33,7 @@ class bStat
 			wp_enqueue_script( $this->id_base );
 		}
 
-		// set up a rewrite rule to cookie alert/newsletter users
+		// set up a rewrite rule to cookie users
 		add_rewrite_rule( $this->options()->identity_cookie->rewrite_base . '/([0-9]+)/(https?:\/\/.+)/?$', 'index.php?' . $this->user_qv . '=$matches[1]&' . $this->redirect_qv . '=$matches[2]', 'top' );
 		// and a rewrite rule to redirect alert/newsletter users without an id
 		add_rewrite_rule( $this->options()->identity_cookie->rewrite_base . '//(https?:\/\/.+)/?$', 'index.php?' . $this->redirect_qv . '=$matches[1]', 'top' );


### PR DESCRIPTION
- the bstat redirect now does not require a wp user id after the /b rewrite base. we do not cookie the user if there is no wp id in the url.

see https://github.com/GigaOM/legacy-pro/issues/3353
